### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/covidcaremap/geo.py
+++ b/covidcaremap/geo.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import geopandas as gpd
 from difflib import SequenceMatcher
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 from covidcaremap.constants import *
 from covidcaremap.data import read_us_counties_gdf, read_us_states_gdf, read_us_hrr_gdf

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -5,6 +5,5 @@ geopandas==0.7.0
 descartes==1.1.0
 us==1.0.0
 requests==2.23.0
-FuzzyWuzzy==0.18.0
-python-Levenshtein==0.12.0
+rapidfuzz==0.2.2
 requests==2.23.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.

It requires https://pypi.org/project/rapidfuzz/ instead of fuzzywuzzy and python-Levenshtein and comes with prebuild wheels on pypi, but I never worked with these jupyter install files, so I am not entirely sure what has to be changed in there