### PR TITLE
Switch to quantile breaks

### DIFF
--- a/notebooks/processing/Compute_Quantile_Breaks.ipynb
+++ b/notebooks/processing/Compute_Quantile_Breaks.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 145,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 152,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,15 +67,25 @@
     "def compute_breaks(features, columns):\n",
     "    prop_values = get_prop_values(features, columns)\n",
     "    for k in prop_values:\n",
-    "        prop_values[k] = np.histogram(prop_values[k], bins=8)[1].tolist()\n",
+    "        # I'm not good enough at Python to know how to make this more DRY. \n",
+    "        # Was struggling with the map function, so let's just do this for now\n",
+    "        prop_values[k] = [np.quantile(prop_values[k], 0, axis = 0), np.quantile(prop_values[k], 0.25, axis = 0), np.quantile(prop_values[k], 0.5, axis = 0), np.quantile(prop_values[k], 0.75, axis = 0), np.quantile(prop_values[k], 1, axis = 0)]\n",
     "    return prop_values"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 153,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'Staffed All Beds': [1.0, 25.0, 65.0, 166.0, 2753.0], 'Licensed All Beds': [1.0, 26.0, 77.0, 200.0, 2753.0], 'Staffed ICU Beds': [0.0, 0.0, 6.0, 17.0, 221.0], 'All Bed Occupancy Rate': [0.0, 0.3011868, 0.49841199999999997, 0.67528155, 1.0], 'ICU Bed Occupancy Rate': [0.0, 0.0, 0.1409132420091324, 0.5743902439024391, 1.0]}\n"
+     ]
+    }
+   ],
    "source": [
     "facility_breaks = compute_breaks(by_facility['features'], columns=(\n",
     "    CCM_FACILITY_COUNT_COLUMNS + \n",
@@ -88,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,14 +108,13 @@
     "    CCM_PER_CAPITA_COLUMNS\n",
     "))\n",
     "\n",
-    "\n",
     "with open(processed_data_path('ccm_county_breaks.json'), 'w') as f:\n",
     "          f.write(json.dumps(county_breaks, indent=4))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 150,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 151,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/processing/Compute_Quantile_Breaks.ipynb
+++ b/notebooks/processing/Compute_Quantile_Breaks.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": 232,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": 233,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 234,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,25 +67,15 @@
     "def compute_breaks(features, columns):\n",
     "    prop_values = get_prop_values(features, columns)\n",
     "    for k in prop_values:\n",
-    "        # I'm not good enough at Python to know how to make this more DRY. \n",
-    "        # Was struggling with the map function, so let's just do this for now\n",
-    "        prop_values[k] = [np.quantile(prop_values[k], 0, axis = 0), np.quantile(prop_values[k], 0.25, axis = 0), np.quantile(prop_values[k], 0.5, axis = 0), np.quantile(prop_values[k], 0.75, axis = 0), np.quantile(prop_values[k], 1, axis = 0)]\n",
+    "        prop_values[k] = np.quantile(prop_values[k], [0, 0.25, 0.5, 0.75, 1], axis = 0).tolist()\n",
     "    return prop_values"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": 235,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'Staffed All Beds': [1.0, 25.0, 65.0, 166.0, 2753.0], 'Licensed All Beds': [1.0, 26.0, 77.0, 200.0, 2753.0], 'Staffed ICU Beds': [0.0, 0.0, 6.0, 17.0, 221.0], 'All Bed Occupancy Rate': [0.0, 0.3011868, 0.49841199999999997, 0.67528155, 1.0], 'ICU Bed Occupancy Rate': [0.0, 0.0, 0.1409132420091324, 0.5743902439024391, 1.0]}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "facility_breaks = compute_breaks(by_facility['features'], columns=(\n",
     "    CCM_FACILITY_COUNT_COLUMNS + \n",
@@ -98,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 236,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 237,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 238,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/processing/Compute_Quantile_Breaks.ipynb
+++ b/notebooks/processing/Compute_Quantile_Breaks.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 232,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 234,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 235,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 236,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 237,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 238,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/viz/us-healthcare-system-capacity/css/main.css
+++ b/viz/us-healthcare-system-capacity/css/main.css
@@ -576,19 +576,42 @@ button.primary,
   color: #666;
 }
 
-.legend {
-  font-size: 14px;
-  padding: 2px 4px;
+.legend-container {
+  display: flex;
   position: absolute;
   bottom: 10px;
-  position: absolute;
-  left: 50%;
-  width: auto;
-  transform: translateX(-50%);
+  left: 0;
+  right: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+#legend {
+  font-size: 14px;
+  padding: 2px 4px;
   z-index: 5000;
   background: white;
-  display: flex;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.25);
+}
+
+.legend-color {
+  display: inline-block;
+  height: 14px;
+  width: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  flex-shrink: 0;
+  position: relative;
+  top: 2px;
+  margin-right: 4px;
+}
+
+.legend-numbers {
+  display: inline-block;
+  margin-right: 10px;
+}
+
+.legend-numbers:last-child {
+  margin-right: 0;
 }
 
 #colors {

--- a/viz/us-healthcare-system-capacity/index.html
+++ b/viz/us-healthcare-system-capacity/index.html
@@ -64,7 +64,7 @@
           <hr />
           <div class="map-options menu" id="indicator">
             <button class="active" onclick="setIndicator(0)">
-              <div class="button-icon" style="color: #8856a7">
+              <div class="button-icon" style="color: #023858">
                 <i class="icon-eye"></i>
                 <i class="icon-eye-off"></i>
               </div>
@@ -77,7 +77,7 @@
               </div>
             </button>
             <button onclick="setIndicator(1)">
-              <div class="button-icon" style="color: #2b8cbe">
+              <div class="button-icon" style="color: #4d004b">
                 <i class="icon-eye"></i>
                 <i class="icon-eye-off"></i>
               </div>
@@ -90,7 +90,7 @@
               </div>
             </button>
             <button onclick="setIndicator(2)">
-              <div class="button-icon" style="color: #2ca25f">
+              <div class="button-icon" style="color: #00441b">
                 <i class="icon-eye"></i>
                 <i class="icon-eye-off"></i>
               </div>
@@ -103,7 +103,7 @@
               </div>
             </button>
             <button onclick="setIndicator(3)">
-              <div class="button-icon" style="color: #345672">
+              <div class="button-icon" style="color: #6c2167">
                 <i class="icon-eye"></i>
                 <i class="icon-eye-off"></i>
               </div>
@@ -116,7 +116,7 @@
               </div>
             </button>
             <button onclick="setIndicator(4)">
-              <div class="button-icon" style="color: #632864">
+              <div class="button-icon" style="color: #2a5675">
                 <i class="icon-eye"></i>
                 <i class="icon-eye-off"></i>
               </div>

--- a/viz/us-healthcare-system-capacity/index.html
+++ b/viz/us-healthcare-system-capacity/index.html
@@ -153,10 +153,8 @@
         </div>
         <div class="map-container">
           <div class="map" id="map">
-            <div class="legend">
-              <div id="legend-min"></div>
-              <div id="colors"></div>
-              <div id="legend-max"></div>
+            <div class="legend-container">
+              <div id="legend"></div>
             </div>
           </div>
         </div>
@@ -164,9 +162,10 @@
     </div>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js"></script>
     <script
-        src="https://code.jquery.com/jquery-3.4.1.min.js"
-        integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
-        crossorigin="anonymous"></script>
+      src="https://code.jquery.com/jquery-3.4.1.min.js"
+      integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
+      crossorigin="anonymous"
+    ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore-min.js"></script>
     <script src="js/color.js"></script>
     <script src="js/main.js"></script>

--- a/viz/us-healthcare-system-capacity/js/main.js
+++ b/viz/us-healthcare-system-capacity/js/main.js
@@ -317,11 +317,15 @@ function setFillPaintStyle(layerName) {
     colors = _.map([...Array(breaksValues.length).keys()], function(i) {
       return palette(i / breaksValues.length);
     }),
+    breaksAndColors = _.flatten(_.zip(breaksValues, colors)),
+    breaksAndColorsWithoutFirstBreak = breaksAndColors.splice(
+      1,
+      breaksAndColors.length
+    ),
     style = [
-      "interpolate",
-      ["linear"],
+      "step",
       ["number", ["get", getProperty(indicator)], breaksValues[0]]
-    ].concat(_.flatten(_.zip(breaksValues, colors)));
+    ].concat(breaksAndColorsWithoutFirstBreak);
 
   setLegend(colors, breaksValues);
 
@@ -391,11 +395,17 @@ function setCirclePaintStyle(layerName) {
     ]
   ]);
 
+  var breaksAndColors = _.flatten(_.zip(breaksValues, colors)),
+    breaksAndColorsWithoutFirstBreak = breaksAndColors.splice(
+      1,
+      breaksAndColors.length
+    );
+
   map.setPaintProperty(
     layerName,
     "circle-color",
-    ["interpolate", ["linear"], ["get", getProperty(indicator)]].concat(
-      _.flatten(_.zip(breaksValues, colors))
+    ["step", ["get", getProperty(indicator)]].concat(
+      breaksAndColorsWithoutFirstBreak
     )
   );
 }

--- a/viz/us-healthcare-system-capacity/js/main.js
+++ b/viz/us-healthcare-system-capacity/js/main.js
@@ -346,7 +346,6 @@ function setFillPaintStyle(layerName) {
 }
 
 function setLegend(colors, breaksValues) {
-  console.log(colors, breaksValues);
   var legend = colors
     .map(function(color, i) {
       return `<div class="legend-color" style="background-color: ${color}"></div><div class="legend-numbers">${formatNumber(breaksValues[i], indicator)}–${formatNumber(breaksValues[i + 1], indicator)}</div>`;

--- a/viz/us-healthcare-system-capacity/js/main.js
+++ b/viz/us-healthcare-system-capacity/js/main.js
@@ -166,35 +166,35 @@ var indicators = [
   {
     propertyInData: "Staffed All Beds",
     label: "Staffed All Beds",
-    colors: ["#e0ecf4", "#8856a7"],
+    colors: ["#fff7fb", "#9db5ce", "#4d7596", "#023858"],
     displayAsPercent: false,
     radii: [[1, 20], [5, 50]]
   },
   {
     propertyInData: "Staffed ICU Beds",
     label: "Staffed ICU Beds",
-    colors: ["#ece7f2", "#2b8cbe"],
+    colors: ["#f7fcfd", "#b0aacb", "#7a5a8d", "#4d004b"],
     displayAsPercent: false,
     radii: [[1, 20], [5, 50]]
   },
   {
     propertyInData: "Licensed All Beds",
     label: "Licensed All Beds",
-    colors: ["#e5f5f9", "#2ca25f"],
+    colors: ["#f7fcfd", "#8cc1aa", "#40825e", "#00441b"],
     displayAsPercent: false,
     radii: [[1, 20], [5, 50]]
   },
   {
     propertyInData: "All Bed Occupancy Rate",
     label: "All Bed Occupancy Rate",
-    colors: ["#D6EDEA", "#345672"],
+    colors: ["#f3e7e9", "#d49ebb", "#a55c90", "#6c2167"],
     displayAsPercent: true,
     radii: [[1, 8], [5, 40]]
   },
   {
     propertyInData: "ICU Bed Occupancy Rate",
     label: "ICU Bed Occupancy Rate",
-    colors: ["#EDCDD3", "#632864"],
+    colors: ["#e9eeed", "#91bec5", "#56899d", "#2a5675"],
     displayAsPercent: true,
     radii: [[1, 8], [5, 40]]
   }
@@ -307,25 +307,38 @@ function getProperty(theIndicator) {
 }
 
 function getBreaks() {
-  return breaks[type][getProperty(indicator)];
+  var breakpoints = breaks[type][getProperty(indicator)];
+  // TODO: Find a better way to handle this
+  // Mapbox's step expression doesn't like it when one of the breakpoints is equal to the smallest
+  // property value; this comes up some places in our map where the first breakpoint is 0, where it
+  // won't style any of the features with a value of 0. I am temporarily getting around this by
+  // adding a very small value to the break point when this happens.
+  var modifiedBreaks = breakpoints.map(function(breakpoint, i) {
+    if (i > 0 && breakpoint === breakpoints[i - 1]) {
+      return breakpoint + 0.0000000000001;
+    } else {
+      return breakpoint;
+    }
+  });
+  return modifiedBreaks;
 }
 
 function setFillPaintStyle(layerName) {
-  var colorsMinMax = indicators[indicator].colors,
-    breaksValues = getBreaks(),
-    palette = interpolate(colorsMinMax),
-    colors = _.map([...Array(breaksValues.length).keys()], function(i) {
-      return palette(i / breaksValues.length);
-    }),
-    breaksAndColors = _.flatten(_.zip(breaksValues, colors)),
-    breaksAndColorsWithoutFirstBreak = breaksAndColors.splice(
-      1,
-      breaksAndColors.length
-    ),
-    style = [
-      "step",
-      ["number", ["get", getProperty(indicator)], breaksValues[0]]
-    ].concat(breaksAndColorsWithoutFirstBreak);
+  var breaksValues = getBreaks();
+  var colors = indicators[indicator].colors;
+  var breaks = _.flatten(_.zip(breaksValues, colors)).splice(
+    1,
+    colors.length + breaksValues.length - 2
+  );
+
+  style = [
+    "case",
+    // Check to make sure property is not undefined
+    ["all", ["has", getProperty(indicator)]],
+    ["step", ["number", ["get", getProperty(indicator)]]].concat(breaks),
+    // Fallback color for undefined indicator
+    "#ccc"
+  ];
 
   setLegend(colors, breaksValues);
 
@@ -333,29 +346,19 @@ function setFillPaintStyle(layerName) {
 }
 
 function setLegend(colors, breaksValues) {
-  document.getElementById("legend-min").innerHTML = formatNumber(
-    breaksValues[0],
-    indicator
-  );
-  document.getElementById("legend-max").innerHTML = formatNumber(
-    breaksValues[breaksValues.length - 1],
-    indicator
-  );
-  document.getElementById(
-    "colors"
-  ).style.backgroundImage = `linear-gradient(to right, ${colors[0]}, ${
-    colors[colors.length - 1]
-  })`;
+  console.log(colors, breaksValues);
+  var legend = colors
+    .map(function(color, i) {
+      return `<div class="legend-color" style="background-color: ${color}"></div><div class="legend-numbers">${formatNumber(breaksValues[i], indicator)}–${formatNumber(breaksValues[i + 1], indicator)}</div>`;
+    })
+    .join("");
+  document.getElementById("legend").innerHTML = legend;
 }
 
 function setCirclePaintStyle(layerName) {
-  var colorsMinMax = indicators[indicator].colors,
+  var colors = indicators[indicator].colors,
     radii = indicators[indicator].radii,
     breaksValues = getBreaks(),
-    palette = interpolate(colorsMinMax),
-    colors = _.map([...Array(breaksValues.length).keys()], function(i) {
-      return palette(i / breaksValues.length);
-    }),
     radiiZ1 = _.map([...Array(breaksValues.length).keys()], function(i) {
       return (i / breaksValues.length) * 19 + 1;
     }),
@@ -365,9 +368,6 @@ function setCirclePaintStyle(layerName) {
 
   map.setLayoutProperty(layerName, "visibility", "visible");
   setLegend(colors, breaksValues);
-
-  // ].concat(_.flatten(_.zip(breaksValues, radiiZ1))),
-  // ].concat(_.flatten(_.zip(breaksValues, radiiZ2)))
 
   map.setPaintProperty(layerName, "circle-radius", [
     "interpolate",
@@ -395,18 +395,17 @@ function setCirclePaintStyle(layerName) {
     ]
   ]);
 
-  var breaksAndColors = _.flatten(_.zip(breaksValues, colors)),
-    breaksAndColorsWithoutFirstBreak = breaksAndColors.splice(
-      1,
-      breaksAndColors.length
-    );
+  var breaksValues = getBreaks();
+  var colors = indicators[indicator].colors;
+  var breaks = _.flatten(_.zip(breaksValues, colors)).splice(
+    1,
+    colors.length + breaksValues.length - 2
+  );
 
   map.setPaintProperty(
     layerName,
     "circle-color",
-    ["step", ["get", getProperty(indicator)]].concat(
-      breaksAndColorsWithoutFirstBreak
-    )
+    ["step", ["number", ["get", getProperty(indicator)]]].concat(breaks)
   );
 }
 
@@ -517,11 +516,6 @@ map.on("load", function() {
       },
       "state-line"
     );
-
-    // map.addSource("facility", {
-    //   type: "geojson",
-    //   data: facilities
-    // });
 
     map.addLayer(
       {


### PR DESCRIPTION
This pull requests switches from equal distance breakpoints to quantile breakpoints, where each bucket has the same number of features. As a result, the visualization looks more interesting and it's easier to distinguish between the high and low values.

![image](https://user-images.githubusercontent.com/1809908/77481370-e5ecb100-6df9-11ea-915d-8ec103748d1d.png)

![image](https://user-images.githubusercontent.com/1809908/77481551-454ac100-6dfa-11ea-84df-a0a8f16e1e9a.png)

@lossyrob the notebook seemed to drop some `"execution_count": 145,` lines in there ... did I do something wrong? Does that need to get cleaned out?

I'm really excited to get this out there! Thanks for getting me set up with the notebooks. I had fun looking at this and it made me want to get back into this side of things.