### PR TITLE
Add form link for data update/correction by users to map

### DIFF
--- a/maps/us-healthcare-system-capacity/index.html
+++ b/maps/us-healthcare-system-capacity/index.html
@@ -35,6 +35,9 @@
           /></a>
         </div>
         <nav>
+          <a target="_blank" href="https://forms.gle/vPqPpgAwqoUgep47A"
+            >Update data</a
+          >
           <a target="_blank" href="https://www.covidcaremap.org/"
             >About/Methodology</a
           ><a


### PR DESCRIPTION
Adds a link at the top of the US health system capacity map that goes to a [google form](https://forms.gle/vPqPpgAwqoUgep47A) for now to enable easier user reporting of facility-level data corrections or additions per #65 