### PR TITLE
Enable redirects for Netlify domain -> primary domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,11 +13,11 @@
 [context.production]
   environment = { JEKYLL_ENV = "production" }
 
-# [[redirects]]
-#   from = "https://covidcaremap.netlify.com/*"
-#   to = "https://www.covidcaremap.org/:splat"
-#   status = 301
-#   force = true
+[[redirects]]
+  from = "https://covidcaremap.netlify.com/*"
+  to = "https://www.covidcaremap.org/:splat"
+  status = 301
+  force = true
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
Just helps prevent folks from navigating to covidcaremap.netlify.com directly.

There isn't a great way to test this because the redirects don't really go into effect under the changes are merged. At the very least, you can navigate to https://covidcaremap.netlify.com now. That should redirect to the primary domain after these changes are deployed.