### PR TITLE
pull chime from correct branch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN pip install dash==1.9.1
 RUN mkdir -p /opt/tmp && \
     cd /opt/tmp && \
     git clone --single-branch --depth 1 \
-        --branch rde/feature/regional-sir-model https://github.com/lossyrob/chime.git && \
+        --branch rde/feature/regional-sir https://github.com/simonkassel/chime.git && \
     cd chime && \
     python setup.py install
 


### PR DESCRIPTION
change the dockerfile to install chime from the correct branch of rob's CHIME fork.

https://github.com/lossyrob/chime/blob/rde/feature/regional-sir/src/penn_chime/utils.py has necessary definitions in utils.py while

https://github.com/lossyrob/chime/blob/rde/feature/regional-sir-model/src/penn_chime/utils.py does not