### PR TITLE
Add ppe package to covidcaremap for PPE burn rate modeling.

### DIFF
--- a/covidcaremap/ppe.py
+++ b/covidcaremap/ppe.py
@@ -1,0 +1,386 @@
+"""
+PPE modeling logic. Taken from work by @Geoiy
+"""
+
+import math
+import json
+from collections import defaultdict
+from itertools import chain
+
+import numpy as np
+import pandas as pd
+
+DEFAULT_PARAMS = {
+
+    # Detection Probability: Used to infer infected population from confirmed cases.
+    "detection_probability": 0.14,
+
+    # Hospitalized Rate: 0.00001 - 1.0
+    "hospitalized_rate": 0.025,
+
+    # Hospitalized Length of Stay (days)
+    "hospitalized_los": 7,
+
+    # ICU Length of Stay (days)
+    "icu_los": 9,
+
+    # ICU Rate: 0.0 - 1.0
+    "icu_rate": 0.0075,
+
+    # Ventilated Rate: 0.0 - 1.0
+    "ventilated_rate": 0.005,
+
+    #Ventilated Length of Stay (days)
+    "ventilated_los": 10,
+
+    # Shift per day for all staff
+    "shifts_per_day": 2,
+
+    # Percentage of triaged patients that are hospitalized.
+    # Default considered 20% positive out of tested and 20% hospitalized out of positive.
+    # 20% hospitalization from https://www.cdc.gov/mmwr/volumes/69/wr/mm6913e2.htm?mod=article_inline
+    "hospitalized_to_traiged_ratio": 0.2 * 0.2
+
+}
+
+### STAFF ###
+
+LAB_TECH = 'lab_tech'
+NURSE = 'nurse'
+MD = 'md'
+EVS = 'evs'
+OTHER_CLINICAL = 'other_clinical'
+SECURITY = 'security'
+TRANSPORT = 'transport'
+PHLEBOTOMY = 'phlebotomy'
+
+### STAGES OF CARE ###
+
+TRIAGE = 'triage'
+HOSPITALIZED = 'hospitalized'
+ICU = 'icu'
+
+### SUPPLIES ###
+
+# Disposable
+N95 = 'n95'
+GOWN = 'gown'
+DROPLET_MASK = 'droplet_mask'
+GLOVES = 'gloves' # pairs
+WIPES = 'wipes' # container
+TEST_KIT = 'test_kit'
+
+# Reusable
+GOGGLES = 'goggles'
+BP_CUFF_ETC = 'bp_cuff_etc' # BP Cuff, Stethoscope, Pulse Ox, Ambu Bag
+VENT = 'ventilator'
+PAPR = 'papr'
+
+class SupplyCounts:
+    def __init__(self, counts=None):
+        if counts is None:
+            self.counts = defaultdict(float)
+        else:
+            self.counts = defaultdict(float, counts)
+
+    def multiply(self, x):
+        result = self.copy()
+        for k in result.counts:
+            result.counts[k] *= x
+        return result
+
+    def add(self, other):
+        result = {}
+        for key in set(chain(self.counts.keys(), other.counts.keys())):
+            result[key] = self.counts.get(key, 0) + other.counts.get(key, 0)
+        return SupplyCounts(counts=result)
+
+    def copy(self):
+        return SupplyCounts(counts=self.counts)
+
+    def get(self, key, default=None):
+        return self.counts.get(key, default)
+
+    def __getitem__(self, key):
+        return self.counts[key]
+
+    def __str__(self):
+        return 'SupplyCounts({})'.format(json.dumps(self.counts))
+
+class StaffSupplyModel:
+    def __init__(self,
+                 per_shift_counts,
+                 per_encounter_counts,
+                 num_patients_per,
+                 encounters_per_patient):
+        self.per_shift_counts = per_shift_counts
+        self.per_encounter_counts = per_encounter_counts
+        self.num_patients_per = num_patients_per
+        self.encounters_per_patient = encounters_per_patient
+
+class CareStageSupplyModel:
+    def __init__(self,
+                 per_patient,
+                 per_staff):
+        self.per_patient = per_patient
+        self.per_staff = per_staff
+
+SUPPLY_MODEL_PER_STAGE = {
+    TRIAGE: CareStageSupplyModel(
+        per_patient=SupplyCounts({ TEST_KIT: 1, DROPLET_MASK: 1}),
+        per_staff={
+            NURSE: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    N95: 2
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=15,
+                encounters_per_patient=1
+            ),
+            MD: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    N95: 2,
+                    GOGGLES: 1
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=30,
+                encounters_per_patient=1
+            ),
+            EVS: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    N95: 2,
+                    GOGGLES: 1
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=20,
+                encounters_per_patient=1
+            ),
+            SECURITY: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    N95: 2,
+                    GOGGLES: 1
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=50, # Estimate, "with prolonged contact"
+                encounters_per_patient=1
+            ),
+            TRANSPORT: StaffSupplyModel(
+                per_shift_counts=SupplyCounts(),
+                per_encounter_counts=SupplyCounts({
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=20,
+                encounters_per_patient=1
+            ),
+            PHLEBOTOMY: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    N95: 2,
+                    GOGGLES: 1
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=300, # Estimate, "Only for blood culture, 3% of ED" - does not give staff ratio. Use 3% against the ICU rate of 10
+                encounters_per_patient=1
+            ),
+            LAB_TECH: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    GLOVES: 7 # Add one for the "other clinical" in Lab Testing
+                }),
+                per_encounter_counts=SupplyCounts(),
+                num_patients_per=170,
+                encounters_per_patient=1
+            ),
+        }
+    ),
+    HOSPITALIZED: CareStageSupplyModel( # "Ward COVID"
+        per_patient=SupplyCounts({ WIPES: 1}),
+        per_staff={
+            NURSE: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    GOGGLES: 2
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=2,
+                encounters_per_patient=6
+            ),
+            MD: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    GOGGLES: 2
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=10,
+                encounters_per_patient=1.2
+            ),
+            EVS: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    GOGGLES: 1,
+                    GLOVES: 2,
+                    GOWN: 2,
+                    DROPLET_MASK: 2
+                }),
+                per_encounter_counts=SupplyCounts(),
+                num_patients_per=1,
+                encounters_per_patient=1
+            ),
+            SECURITY: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    GOGGLES: 2
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=10,
+                encounters_per_patient=1
+            ),
+            PHLEBOTOMY: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    GOGGLES: 2
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=10,
+                encounters_per_patient=1.5
+            )
+        }
+    ),
+    ICU: CareStageSupplyModel(
+        per_patient=SupplyCounts({ WIPES: 1}),
+        per_staff={
+            NURSE: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    N95: 2,
+                    GOGGLES: 2
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=2,
+                encounters_per_patient=6
+            ),
+            MD: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    GOGGLES: 2
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=10,
+                encounters_per_patient=1.2
+            ),
+            EVS: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    N95: 2,
+                    GOGGLES: 1,
+                    GLOVES: 2,
+                    GOWN: 2,
+                    DROPLET_MASK: 2
+                }),
+                per_encounter_counts=SupplyCounts(),
+                num_patients_per=1,
+                encounters_per_patient=1
+            ),
+            SECURITY: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    GOGGLES: 2
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=10,
+                encounters_per_patient=1
+            ),
+            PHLEBOTOMY: StaffSupplyModel(
+                per_shift_counts=SupplyCounts({
+                    GOGGLES: 2
+                }),
+                per_encounter_counts=SupplyCounts({
+                    GOWN: 1,
+                    DROPLET_MASK: 1,
+                    GLOVES: 1
+                }),
+                num_patients_per=10,
+                encounters_per_patient=1.5
+            )
+        }
+    )
+}
+
+def calculate_ppe_burn_for_day(new_hospitalized,
+                               new_icu,
+                               new_triaged=None,
+                               params=None,
+                               ppes=None):
+    if params is None:
+        params = DEFAULT_PARAMS
+
+    if ppes is None:
+        ppes = [N95, GOWN, DROPLET_MASK, GLOVES, WIPES]
+
+    if new_triaged is None:
+        # Estimate based on ratio
+        new_triaged = new_hospitalized / params['hospitalized_to_traiged_ratio']
+
+    counts = SupplyCounts()
+    for key, patient_count in {
+            TRIAGE: new_triaged,
+            HOSPITALIZED: new_hospitalized,
+            ICU: new_icu
+    }.items():
+        stage_model = SUPPLY_MODEL_PER_STAGE[key]
+        counts = counts.add(stage_model.per_patient.multiply(patient_count))
+        for staff_type, staff_model in stage_model.per_staff.items():
+            staff_needed = math.ceil(patient_count / staff_model.num_patients_per)
+
+            # Estimate staff needed to cover patients and their shift usage.
+            shifts_per_day = staff_needed * params['shifts_per_day']
+            counts = counts.add(
+                staff_model.per_shift_counts.multiply(shifts_per_day)
+            )
+
+            # Estimate usage for number of encounters per day with patients
+            encounters_per_day = staff_needed * staff_model.encounters_per_patient
+            counts = counts.add(
+                staff_model.per_encounter_counts.multiply(encounters_per_day)
+            )
+
+    result = dict([(ppe, math.ceil(counts.get(ppe, np.nan))) for ppe in ppes])
+    return result

--- a/docker/test
+++ b/docker/test
@@ -1,0 +1,31 @@
+ #!/bin/bash
+
+set -e
+
+if [[ -n "${COVID19_DEBUG}" ]]; then
+    set -x
+fi
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do SOURCE="$(readlink "$SOURCE")"; done
+SCRIPTS_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+PROJECT_ROOT="$(cd -P "$(dirname "$SCRIPTS_DIR")" && pwd)"
+
+DATA_DIR="${COVID19_DATA_DIR:-${PROJECT_ROOT}/data}"
+NOTEBOOK_DIR="${COVID19_NOTEBOOK_DIR:-${PROJECT_ROOT}/nbs}"
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Launch Bash within the Jupyter container image.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    docker run --rm -it \
+        -v "$PROJECT_ROOT":/opt/src \
+        -v "$DATA_DIR":/opt/jupyter/data \
+        -v "$NOTEBOOK_DIR":/opt/jupyter/nbs \
+        --entrypoint /bin/bash  \
+        covid19:latest -c "python -m unittest discover tests"
+fi

--- a/notebooks/processing/PPE_Burn_Rate_from_IHME.ipynb
+++ b/notebooks/processing/PPE_Burn_Rate_from_IHME.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "from covidcaremap.ihme import IHME\n",
+    "from covidcaremap.ppe import calculate_ppe_burn_for_day"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.set_option('display.max_columns', None)\n",
+    "pd.set_option('display.max_rows', 100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = IHME.get_latest()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ppe_per_day(row):\n",
+    "    ppes = calculate_ppe_burn_for_day(row[IHME.NEW_HOSPITALIZED_MEAN], \n",
+    "                                      row[IHME.NEW_ICU_MEAN])\n",
+    "    return pd.Series(ppes)\n",
+    "\n",
+    "dfm = df.join(df.apply(ppe_per_day, axis=1))\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dfm[(dfm['location_name'] == 'New York') & (dfm['deaths_mean'] > 0.0)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_ppe.py
+++ b/tests/test_ppe.py
@@ -1,0 +1,60 @@
+import unittest
+import math
+from collections import defaultdict
+
+import numpy as np
+import pandas as pd
+import geopandas as gpd
+
+from covidcaremap.ppe import (calculate_ppe_burn_for_day,
+                              SUPPLY_MODEL_PER_STAGE,
+                              ICU,
+                              TRIAGE,
+                              HOSPITALIZED,
+                              DEFAULT_PARAMS,
+                              N95,
+                              GOWN,
+                              DROPLET_MASK,
+                              GLOVES,
+                              WIPES)
+
+from covidcaremap.data import (processed_data_path,
+                               external_data_path,
+                               local_data_path)
+from covidcaremap.mapping import HospMap
+
+from covidcaremap.merge import match_facilities, FacilityColumns
+
+class PPETest(unittest.TestCase):
+    def test_calculate_burn_works_on_small_example(self):
+        new_triaged = 1
+        new_hospitalized = 1
+        new_icu = 1
+
+        ppes = [N95, GOWN, DROPLET_MASK, GLOVES, WIPES]
+        result = calculate_ppe_burn_for_day(new_hospitalized, new_icu, new_triaged=new_triaged, ppes=ppes)
+
+        # Do a more manual calculation
+        expected = defaultdict(float)
+        for stage in [TRIAGE, HOSPITALIZED, ICU]:
+            for k, v in SUPPLY_MODEL_PER_STAGE[stage].per_patient.counts.items():
+                if k in ppes:
+                    expected[k] += v
+            for staff, staff_model in SUPPLY_MODEL_PER_STAGE[stage].per_staff.items():
+                for k, v in staff_model.per_shift_counts.counts.items():
+                    if k in ppes:
+                        expected[k] += v * DEFAULT_PARAMS['shifts_per_day']
+
+                for k, v in staff_model.per_encounter_counts.counts.items():
+                    if k in ppes:
+                        expected[k] += (v * staff_model.encounters_per_patient)
+
+        for ppe in ppes:
+            if not ppe in expected:
+                expected[ppe] = np.nan
+            else:
+                expected[ppe] = math.ceil(expected[ppe])
+
+        self.assertEqual(set(result.keys()), set(expected.keys()))
+        for k in result.keys():
+            self.assertEqual(result[k], expected[k], msg='Failed with {}'.format(k))


### PR DESCRIPTION
Based on the excellent work by @Geoyi in the [PPE_needs_for_confirmed_covid-19_at_county_level](https://github.com/covidcaremap/covid19-healthsystemcapacity/blob/da3762565b2db7f4d90a643f54a3cf28b04c96b8/notebooks/processing/PPE_needs_for_confirmed_covid-19_at_county_level.ipynb) notebook.

Refactor the implementation of PPE calculation to be based on a configuration dictionary that can be more easily updated and manipulated.

See [this page](https://rpubs.com/Geoyi/PPE_need_usa_convid19) for notes on methodology.

Based on the model by a group from Northwestern U. See discussion in #45 for more information. The model image used to generate and check the model is here:

![COVID-19 PPE Use_30 March 2020](https://user-images.githubusercontent.com/2320142/80286927-5c801580-86fc-11ea-8d14-e50e317ecc3c.png)

After discussion about how much of the model we could encapsulate, the only components implemented from the model above are A. disposable PPEs and B. only the ED/OB Triage, Lab Testing, Ward COVID, and Critical Care COVID stages are modeled. This is based on the information that is available, both for actuals and from forecasts like IHME's model.

Additional methodology documentation should be made as part of a follow up PR; this PR is intended to get the current progress of work into the codebase.

This PR also adds unit testing. This should be integrated into a CI step in follow up PRs.