### PR TITLE
Speed up netlify builds

### DIFF
--- a/maps/_ihme-explorer/scripts/cibuild
+++ b/maps/_ihme-explorer/scripts/cibuild
@@ -34,16 +34,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Replace all instances of NaN with null
         sed -i.bak 's/NaN/null/' build-cache/*.geojson
 
-        # Install tippecanoe
-        if [ ! -d $NETLIFY_CACHE_DIR/tippecanoe-1.32.5 ]; then
-            wget -qO- https://github.com/mapbox/tippecanoe/archive/1.32.5.tar.gz |
-                tar xvz -C build-cache/
-            make -C build-cache/tippecanoe-1.32.5
-            cp -R build-cache/tippecanoe-1.32.5 $NETLIFY_CACHE_DIR/tippecanoe-1.32.5
-        fi
-
-        export PATH=$NETLIFY_CACHE_DIR/tippecanoe-1.32.5:$PATH
-
         # Generate intermediate data set
         tippecanoe -f -pk --no-tile-compression -o build-cache/country.mbtiles \
                    --maximum-zoom=8 --minimum-zoom=0 -l country build-cache/ihme-country-data.geojson

--- a/maps/_ihme-explorer/scripts/cibuild
+++ b/maps/_ihme-explorer/scripts/cibuild
@@ -40,22 +40,9 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         tippecanoe -f -pk --no-tile-compression -o build-cache/region.mbtiles \
             --maximum-zoom=8 --minimum-zoom=0 -l region build-cache/ihme-region-data.geojson
 
-        tile-join -f -pk --no-tile-compression -o build-cache/combined.mbtiles \
+        tile-join -f -pk --no-tile-compression -e data/tiles \
             build-cache/country.mbtiles \
             build-cache/region.mbtiles
-
-        # Install mb-util
-        if [ ! -d $NETLIFY_CACHE_DIR/mbutil-0.3.0 ]; then
-            wget -qO- https://github.com/mapbox/mbutil/archive/v0.3.0.tar.gz |
-                tar xvz -C build-cache/
-            cp -R build-cache/mbutil-0.3.0 $NETLIFY_CACHE_DIR/mbutil-0.3.0
-        fi
-
-        export PATH=$NETLIFY_CACHE_DIR/mbutil-0.3.0:$PATH
-
-        # Generate vector tiles
-        rm -rf data/tiles
-        mb-util --image_format=pbf build-cache/combined.mbtiles data/tiles
 
         # Build React application
         npm install

--- a/maps/_us_healthcare-system-capacity/scripts/cibuild
+++ b/maps/_us_healthcare-system-capacity/scripts/cibuild
@@ -39,16 +39,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Replace all instances of NaN with null
         sed -i.bak 's/NaN/null/' build-cache/*.geojson
 
-        # Install tippecanoe
-        if [ ! -d $NETLIFY_CACHE_DIR/tippecanoe-1.32.5 ]; then
-            wget -qO- https://github.com/mapbox/tippecanoe/archive/1.32.5.tar.gz |
-                tar xvz -C build-cache/
-            make -C build-cache/tippecanoe-1.32.5
-            cp -R build-cache/tippecanoe-1.32.5 $NETLIFY_CACHE_DIR/tippecanoe-1.32.5
-        fi
-
-        export PATH=$NETLIFY_CACHE_DIR/tippecanoe-1.32.5:$PATH
-
         # Generate intermediate data set
         tippecanoe -f -pk --no-tile-compression -o build-cache/state.mbtiles \
             --maximum-zoom=8 --minimum-zoom=2 -l state build-cache/us_healthcare_capacity-state-CovidCareMap.geojson

--- a/maps/_us_healthcare-system-capacity/scripts/cibuild
+++ b/maps/_us_healthcare-system-capacity/scripts/cibuild
@@ -49,24 +49,11 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         tippecanoe -f -pk -pf --no-tile-compression -o build-cache/facility.mbtiles \
             --maximum-zoom=8 --minimum-zoom=2 -B 0 -l facility build-cache/us_healthcare_capacity-facility-CovidCareMap.geojson
 
-        tile-join -f -pk --no-tile-compression -o build-cache/combined.mbtiles \
+        tile-join -f -pk --no-tile-compression -e data/tiles \
             build-cache/county.mbtiles \
             build-cache/state.mbtiles \
             build-cache/hrr.mbtiles \
             build-cache/facility.mbtiles
-
-        # Install mb-util
-        if [ ! -d $NETLIFY_CACHE_DIR/mbutil-0.3.0 ]; then
-            wget -qO- https://github.com/mapbox/mbutil/archive/v0.3.0.tar.gz |
-                tar xvz -C build-cache/
-            cp -R build-cache/mbutil-0.3.0 $NETLIFY_CACHE_DIR/mbutil-0.3.0
-        fi
-
-        export PATH=$NETLIFY_CACHE_DIR/mbutil-0.3.0:$PATH
-
-        # Generate vector tiles
-        rm -rf data/tiles
-        mb-util --image_format=pbf build-cache/combined.mbtiles data/tiles
 
         # Build React application
         npm install

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -24,6 +24,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         bundle config set path "$NETLIFY_CACHE_DIR/bundle"
         jekyll build
 
+        # Install tippecanoe
+        if [ ! -d $NETLIFY_CACHE_DIR/tippecanoe-1.32.5 ]; then
+            wget -qO- https://github.com/mapbox/tippecanoe/archive/1.32.5.tar.gz |
+                tar xvz -C build-cache/
+            make -C build-cache/tippecanoe-1.32.5
+            cp -R build-cache/tippecanoe-1.32.5 $NETLIFY_CACHE_DIR/tippecanoe-1.32.5
+        fi
+
+        export PATH=$NETLIFY_CACHE_DIR/tippecanoe-1.32.5:$PATH
+
         mkdir -p "${DIR}/../_site/maps"
 
         for map in "${DIR}"/../maps/*; do


### PR DESCRIPTION
This PR attempts to speed up the netlify builds by modifying the cibuild scripts to only install tippecanoe once and avoid using mbutils, instead using the `-e` option in tippecanoe to generate vector tiles.