### PR TITLE
Remove tile-join for IHME vector tile creation.

### DIFF
--- a/maps/_ihme-explorer/scripts/cibuild
+++ b/maps/_ihme-explorer/scripts/cibuild
@@ -35,14 +35,11 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         sed -i.bak 's/NaN/null/' build-cache/*.geojson
 
         # Generate intermediate data set
-        tippecanoe -f -pk --no-tile-compression -o build-cache/country.mbtiles \
-                   --maximum-zoom=8 --minimum-zoom=0 -l country build-cache/ihme-country-data.geojson
-        tippecanoe -f -pk --no-tile-compression -o build-cache/region.mbtiles \
-            --maximum-zoom=8 --minimum-zoom=0 -l region build-cache/ihme-region-data.geojson
-
-        tile-join -f -pk --no-tile-compression -e data/tiles \
-            build-cache/country.mbtiles \
-            build-cache/region.mbtiles
+        tippecanoe -f -pk -pf --no-tile-compression \
+                   --maximum-zoom=8 --minimum-zoom=0 \
+                   -e data/tiles \
+                   --named-layer=country:build-cache/ihme-country-data.geojson \
+                   --named-layer=region:build-cache/ihme-region-data.geojson
 
         # Build React application
         npm install


### PR DESCRIPTION
In an attempt to reduce netlify build times, which is causing #133 to fail, remove the `tile-join` step in the IHME vector tile creation step and combine layers using tippecanoe directly with the `--named-layer` option.