### PR TITLE
Sort keys for IHME data output.

### DIFF
--- a/notebooks/processing/Process_IHME_data.ipynb
+++ b/notebooks/processing/Process_IHME_data.ipynb
@@ -521,7 +521,7 @@
    "outputs": [],
    "source": [
     "with open(country_geojson_path, 'w') as f:\n",
-    "    f.write(json.dumps(country_feature_collection))"
+    "    f.write(json.dumps(country_feature_collection, sort_keys=True))"
    ]
   },
   {
@@ -531,7 +531,7 @@
    "outputs": [],
    "source": [
     "with open(region_geojson_path, 'w') as f:\n",
-    "    f.write(json.dumps(region_feature_collection))"
+    "    f.write(json.dumps(region_feature_collection, sort_keys=True))"
    ]
   },
   {
@@ -541,7 +541,7 @@
    "outputs": [],
    "source": [
     "with open(processed_data_path('ihme-config.json'), 'w') as f:\n",
-    "    f.write(json.dumps(ihme_config, indent=4))"
+    "    f.write(json.dumps(ihme_config, indent=4, sort_keys=True))"
    ]
   },
   {


### PR DESCRIPTION
This ensures that data updates are only triggered on new data.

The new IHME data produced by this change will be merged in as part of #140 