### PR TITLE
Fix Netlify builds.

### DIFF
--- a/maps/_ihme-explorer/scripts/cibuild
+++ b/maps/_ihme-explorer/scripts/cibuild
@@ -19,7 +19,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        . "/usr/local/bin/run-build-functions.sh"
 
         mkdir -p build-cache
         mkdir -p data

--- a/maps/_us_healthcare-system-capacity/scripts/cibuild
+++ b/maps/_us_healthcare-system-capacity/scripts/cibuild
@@ -19,7 +19,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        . "/usr/local/bin/run-build-functions.sh"
 
         mkdir -p build-cache
         mkdir -p data/config

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -15,11 +15,15 @@ Generate the site!
 "
 }
 
+NETLIFY_CACHE_DIR="/opt/buildhome/cache"
+
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        . "/usr/local/bin/run-build-functions.sh"
+
+        mkdir -p ./build-cache/
+        mkdir -p ${NETLIFY_CACHE_DIR}
 
         bundle config set path "$NETLIFY_CACHE_DIR/bundle"
         jekyll build


### PR DESCRIPTION
This removes a call to "run-build_functions.sh" which is not required and was removed from the Netlify build environment. It also manually sets the NETLIFY_CACHE_DIR which was removed from the Netlify build environment.