### PR TITLE
Fix Dockerfile build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.8.6
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
      libspatialindex-dev \


### PR DESCRIPTION
The HSCAP data processing workflow was broken due to the fact that the docker image required was unable to build. This is because the base docker image declared was `python:3`, which is a Dockerhub hosted Python 3 image tag. Python just released 3.9, which upped the `python:3` image to the 3.9 version. Some projects like scipy and numpy have not yet published wheels for this version, and so the requirements install step is broken in the docker build step. This change pins the base docker image to the more specific `python:3.8.6` version, which can build cleanly.