### PR TITLE
Suspend IHME automatic updates.

### DIFF
--- a/.github/workflows/ihme_data_update.yml
+++ b/.github/workflows/ihme_data_update.yml
@@ -9,8 +9,8 @@ on:
   push:
     branches:
       - feature/automatic-data-update
-  schedule:
-    - cron: "0 0 * * *"
+  # schedule:
+  #   - cron: "0 0 * * *"
 
 jobs:
   publish_ihme:


### PR DESCRIPTION
The data updates for IHME are broken, and the fix to add expanded regions to new model output is non-trivial. Suspend automatic updates until this fix is requested and put into place.

If anyone is using this map for a purpose and wants to see this be updated with new model versions, let me know. Otherwise I am deprecating maintenance of the map. The IHME map displays the model version so the current map on the site is valid for that past model version, but will not be updated.