### PR TITLE
Fix Docker build due to urllib3 dependency conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,12 @@ RUN pip install python-dateutil==2.8.0
 RUN pip install dash==1.9.1
 
 ## Install chime
-RUN mkdir -p /opt/tmp && \
-    cd /opt/tmp && \
-    git clone --single-branch --depth 1 \
-        --branch rde/feature/regional-sir-model https://github.com/lossyrob/chime.git && \
-    cd chime && \
-    python setup.py install
+# RUN mkdir -p /opt/tmp && \
+#     cd /opt/tmp && \
+#     git clone --single-branch --depth 1 \
+#         --branch rde/feature/regional-sir-model https://github.com/lossyrob/chime.git && \
+#     cd chime && \
+#     python setup.py install
 
 WORKDIR /opt/src
 


### PR DESCRIPTION
HSCAP data update automation was broken due to pip install dependency conflict between pysal, urllib3 and botocore. 

Keeping pysal and its requirement of urllib3 < 1.25 over botocore requiring urllib3 >= 1.25.4. 

Forgoing CHIME installation in the Dockerfile removes the need for boto and also sets up for #163 